### PR TITLE
Reset OSRELEASE in container before jlab.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN mkdir map_directory && \
 
 # Create entry point bash script
 RUN echo '#!/bin/bash'                                > /entrypoint.sh && \
+    echo 'unset OSRELEASE                             >> /entrypoint.sh && \
     echo 'source $JLAB_ROOT/$JLAB_VERSION/ce/jlab.sh' >> /entrypoint.sh && \
     echo 'cd $REMOLL && exec ./build/remoll $1'  >> /entrypoint.sh && \
     chmod +x /entrypoint.sh


### PR DESCRIPTION
OSRELEASE is inherited from the calling system. If OSRELEASE is defined there, it is likely not set to the correct value for the container. In that case, reset OSRELEASE and get jlab.sh to redefine it according to what's it the container.

Although one might argue that the user should unset OSRELEASE before using the container, this will likely stump users who have jlab.sh already loaded.